### PR TITLE
Switch from deprecated jsxBracketSameLine to bracketSameLine. Closed #16

### DIFF
--- a/modern.js
+++ b/modern.js
@@ -42,8 +42,8 @@ module.exports = {
       'error',
       {
         arrowParens: 'avoid',
+        bracketSameLine: true,
         bracketSpacing: true,
-        jsxBracketSameLine: true,
         parser: 'typescript',
         printWidth: 130,
         semi: false,


### PR DESCRIPTION
Relevante Doku zu dieser Änderung: https://prettier.io/docs/en/options.html#bracket-line